### PR TITLE
change trader price

### DIFF
--- a/DayZ_Epoch_11.Chernarus/dayz_code/configs/Category - Namalsk - Overwatch/sniperRifleAmmo.hpp
+++ b/DayZ_Epoch_11.Chernarus/dayz_code/configs/Category - Namalsk - Overwatch/sniperRifleAmmo.hpp
@@ -6,8 +6,8 @@ class Category_624 {
 	};
 	class 5Rnd_762x51_M24 {
 		type = "trade_items";
-		buy[] = {100,"worth"};
-		sell[] = {50,"worth"};
+		buy[] = {1000,"worth"};
+		sell[] = {500,"worth"};
 	};
 	class 20Rnd_762x51_DMR {
 		type = "trade_items";
@@ -16,7 +16,7 @@ class Category_624 {
 	};
 	class 10Rnd_762x54_SVD {
 		type = "trade_items";
-		buy[] = {200,"worth"};
-		sell[] = {100,"worth"};
+		buy[] = {2000,"worth"};
+		sell[] = {1000,"worth"};
 	};
 };

--- a/DayZ_Epoch_11.Chernarus/dayz_code/configs/Category - Namalsk/sniperRifleAmmo.hpp
+++ b/DayZ_Epoch_11.Chernarus/dayz_code/configs/Category - Namalsk/sniperRifleAmmo.hpp
@@ -6,8 +6,8 @@ class Category_624 {
 	};
 	class 5Rnd_762x51_M24 {
 		type = "trade_items";
-		buy[] = {100,"worth"};
-		sell[] = {50,"worth"};
+		buy[] = {1000,"worth"};
+		sell[] = {500,"worth"};
 	};
 	class 20Rnd_762x51_DMR {
 		type = "trade_items";
@@ -16,7 +16,7 @@ class Category_624 {
 	};
 	class 10Rnd_762x54_SVD {
 		type = "trade_items";
-		buy[] = {200,"worth"};
-		sell[] = {100,"worth"};
+		buy[] = {2000,"worth"};
+		sell[] = {1000,"worth"};
 	};
 };

--- a/DayZ_Epoch_11.Chernarus/dayz_code/configs/Category - Overwatch/sniperRifleAmmo.hpp
+++ b/DayZ_Epoch_11.Chernarus/dayz_code/configs/Category - Overwatch/sniperRifleAmmo.hpp
@@ -6,8 +6,8 @@ class Category_624 {
 	};
 	class 5Rnd_762x51_M24 {
 		type = "trade_items";
-		buy[] = {100,"worth"};
-		sell[] = {50,"worth"};
+		buy[] = {1000,"worth"};
+		sell[] = {500,"worth"};
 	};
 	class 20Rnd_762x51_DMR {
 		type = "trade_items";
@@ -16,7 +16,7 @@ class Category_624 {
 	};
 	class 10Rnd_762x54_SVD {
 		type = "trade_items";
-		buy[] = {200,"worth"};
-		sell[] = {100,"worth"};
+		buy[] = {2000,"worth"};
+		sell[] = {1000,"worth"};
 	};
 };

--- a/DayZ_Epoch_11.Chernarus/dayz_code/configs/Category/sniperRifleAmmo.hpp
+++ b/DayZ_Epoch_11.Chernarus/dayz_code/configs/Category/sniperRifleAmmo.hpp
@@ -6,8 +6,8 @@ class Category_624 {
 	};
 	class 5Rnd_762x51_M24 {
 		type = "trade_items";
-		buy[] = {100,"worth"};
-		sell[] = {50,"worth"};
+		buy[] = {1000,"worth"};
+		sell[] = {500,"worth"};
 	};
 	class 20Rnd_762x51_DMR {
 		type = "trade_items";
@@ -16,7 +16,7 @@ class Category_624 {
 	};
 	class 10Rnd_762x54_SVD {
 		type = "trade_items";
-		buy[] = {200,"worth"};
-		sell[] = {100,"worth"};
+		buy[] = {2000,"worth"};
+		sell[] = {1000,"worth"};
 	};
 };


### PR DESCRIPTION
Change price to prevent trader exploits: 
- Players can buy 4x 5Rnd_762x51_M24 for 400coins, then combine them into 1 DMR round which is sold for 3000 coins (item right below it). They benefit 2600$ for each transaction. That can be abused by trading a big amount from vehicles so they can gain a lot of coins.